### PR TITLE
Fix an issue in the Section 3 Simulate.ps1 script

### DIFF
--- a/section3/Simulate.ps1
+++ b/section3/Simulate.ps1
@@ -48,7 +48,6 @@ function SwitchDependency() {
         $maintainedDependencyPath = Join-Path $maintainedDependencyFolderPath $dependencyFileName
         Write-Host 'Keeping the old dependency...' -ForegroundColor Magenta
         Copy-Item -Path $pathToOverwrite -Destination $maintainedDependencyPath -Force
-        return
     }
 
     Write-Host 'Overwriting the dependency from package version 12.0.3 with 13.0.3...' -ForegroundColor Magenta


### PR DESCRIPTION
This change fixes an issue I found in the `Simulate.ps1` script for Section 3 where `KeepOldDependency` prevented overwriting the dependency in the original location with the 13.0.0.0 version.