### PR TITLE
Update to .NET 8 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ participants will have a solid understanding of binding redirects and how to use
 * Windows
   * While the concepts demonstrated here are applicable to .NET Framework applications running on other platforms,
     the tutorial will assume you're using Windows.
-* [.NET SDK 6.0+](https://dotnet.microsoft.com/download/dotnet/6.0)
+* [.NET SDK 8.0+](https://dotnet.microsoft.com/download/dotnet/8.0)
 * [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer)
 * [ILSpy](https://github.com/icsharpcode/ILSpy)
 * [PowerShell](https://learn.microsoft.com/powershell/scripting/install/installing-powershell)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.400",
+    "version": "8.0.100",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }

--- a/section2/Section2.csproj
+++ b/section2/Section2.csproj
@@ -4,6 +4,10 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net472</TargetFramework>
     <LangVersion>10.0</LangVersion>
+    <!-- .NET 8 began warning on vulnerable packages. Newtonsoft.Json 12.0.3 does
+    contain security vulnerabilities and should not be used in production. It is
+    used here for demonstration purposes. -->
+    <NoWarn>$(NoWarn);NU1903</NoWarn>
   </PropertyGroup>
 
   <!-- Assembly version information -->

--- a/section3/Section3.csproj
+++ b/section3/Section3.csproj
@@ -4,6 +4,10 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net472</TargetFramework>
     <LangVersion>10.0</LangVersion>
+    <!-- .NET 8 began warning on vulnerable packages. Newtonsoft.Json 12.0.3 does
+    contain security vulnerabilities and should not be used in production. It is
+    used here for demonstration purposes. -->
+    <NoWarn>$(NoWarn);NU1903</NoWarn>
   </PropertyGroup>
 
   <!-- Assembly version information -->

--- a/section5/Section5.csproj
+++ b/section5/Section5.csproj
@@ -2,8 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
+    <!-- .NET 8 began warning on vulnerable packages. Newtonsoft.Json 12.0.3 does
+    contain security vulnerabilities and should not be used in production. It is
+    used here for demonstration purposes. -->
+    <NoWarn>$(NoWarn);NU1903</NoWarn>
   </PropertyGroup>
 
   <!-- Assembly version information -->

--- a/section5/Simulate.ps1
+++ b/section5/Simulate.ps1
@@ -13,7 +13,7 @@ $projectFolder = $PSScriptRoot
 function RunApp() {
     $projectFilePath = Get-Item -Path $projectFolder -Filter *.csproj
     $projectName = [System.IO.Path]::GetFileNameWithoutExtension($projectFilePath)
-    & "./bin/Debug/net6.0/publish/$projectName.exe" Hello World!
+    & "./bin/Debug/net8.0/publish/$projectName.exe" Hello World!
 }
 
 function SwitchDependency() {
@@ -40,7 +40,7 @@ function SwitchDependency() {
     }
 
     $newDependencyPath = Join-Path $extractPath "lib/$SwitchDependencyTfm/Newtonsoft.Json.dll"
-    $pathToOverwrite = Join-Path $projectFolder 'bin/Debug/net6.0/publish/Newtonsoft.Json.dll'
+    $pathToOverwrite = Join-Path $projectFolder 'bin/Debug/net8.0/publish/Newtonsoft.Json.dll'
 
     Write-Host "Overwriting the dependency from package version 12.0.3 with $SwitchDependencyPackageVersion..." -ForegroundColor Magenta
     Copy-Item -Path $newDependencyPath -Destination $pathToOverwrite -Force
@@ -48,7 +48,7 @@ function SwitchDependency() {
 
 Push-Location $projectFolder
 try {
-    $publishOutputFolder = Join-Path $projectFolder 'bin/Debug/net6.0/publish'
+    $publishOutputFolder = Join-Path $projectFolder 'bin/Debug/net8.0/publish'
     if (Test-Path $publishOutputFolder) {
         Write-Host 'Cleaning the publish output folder...' -ForegroundColor Magenta
         Remove-Item -Path $publishOutputFolder -Recurse -Force


### PR DESCRIPTION
This change updates the repo to use the .NET 8 SDK as well as the `net8.0` TFM in Section5.

Also, I had added a `<NoWarn>$(NoWarn);NU1903</NoWarn>` in order to suppress `NU1903` along with a message indicating why. These warnings are [new](https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/dotnet-restore-audit) to .NET 8.